### PR TITLE
Switch from `segmengation-models-pytorch` to `torchseg`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ plot_image_and_mask(img, pred, alpha=0.8, title='My segmentation', colors=DEFAUL
 
 ## Models available
 
-Currently, only a single model is made available (`unet` with a `timm-resnest50 encoder`). More will come regularly.
+Currently, only a single model is made available (`unet` with a `resnest50` encoder). More will come regularly.
 
 ## Variants
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,10 @@ build-backend = "hatchling.build"
 [project]
 name = "fundus_lesions_toolkit"
 version = "0.1.1"
-authors = [
-  { name="Clement Playout", email="clement.playout@polymtl.ca" },
-]
+authors = [{ name = "Clement Playout", email = "clement.playout@polymtl.ca" }]
 description = "Tools for lesions segmentation in retinal fundus images"
 readme = "README.md"
-requires-python = ">=3.5"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
@@ -19,11 +17,14 @@ classifiers = [
 dependencies = [
     "numpy",
     "opencv-python-headless",
-    "segmentation_models_pytorch",
+    "torchseg",
     "pandas",
     "torch",
     "torchvision",
+    "matplotlib",
+    "kornia",
 ]
+
 [project.urls]
 "Homepage" = "https://github.com/ClementPla/fundus-lesions-toolkit/"
 "Bug Tracker" = "https://github.com/ClementPla/fundus-lesions-toolkit/issues"

--- a/src/fundus_lesions_toolkit/models/checkpoints.py
+++ b/src/fundus_lesions_toolkit/models/checkpoints.py
@@ -1,32 +1,32 @@
 DOWNLOADABLE_MODELS = {
     (
         "unet",
-        "timm-resnest50d",
+        "resnest50d",
         "all",
     ): "https://www.googleapis.com/drive/v3/files/1m4QtFZOLg3Pns5HcbSXDskKZn56KkZo5?alt=media&key=AIzaSyAFjU7_3uVx-VGHhp9Kvsda3Su5Ibd_5ys",
     (
         "unet",
-        "timm-resnest50d",
+        "resnest50d",
         "messidor",
     ): "https://www.googleapis.com/drive/v3/files/1Ob-PKR0dg3KUxsZIFJAtKtboIKph71H9?alt=media&key=AIzaSyAFjU7_3uVx-VGHhp9Kvsda3Su5Ibd_5ys",
     (
         "unet",
-        "timm-resnest50d",
+        "resnest50d",
         "ddr",
     ): "https://www.googleapis.com/drive/v3/files/1RZKHFc3FjYwtlzEv9o_rFBFL2aUW17uh?alt=media&key=AIzaSyAFjU7_3uVx-VGHhp9Kvsda3Su5Ibd_5ys",
     (
         "unet",
-        "timm-resnest50d",
+        "resnest50d",
         "retinal_lesions",
     ): "https://www.googleapis.com/drive/v3/files/1MdmfC7O7Tuj9L6FVDN6D8OLutOWqWeKK?alt=media&key=AIzaSyAFjU7_3uVx-VGHhp9Kvsda3Su5Ibd_5ys",
     (
         "unet",
-        "timm-resnest50d",
+        "resnest50d",
         "fgadr",
     ): "https://www.googleapis.com/drive/v3/files/1q_SmpW8EAK4ppKwrY6-KUyNdnSKKzGZH?alt=media&key=AIzaSyAFjU7_3uVx-VGHhp9Kvsda3Su5Ibd_5ys",
     (
         "unet",
-        "timm-resnest50d",
+        "resnest50d",
         "idrid",
     ): "https://www.googleapis.com/drive/v3/files/1DI5EcHPkhfl1LdML1jYCxipXYnNhG4Lx?alt=media&key=AIzaSyAFjU7_3uVx-VGHhp9Kvsda3Su5Ibd_5ys",
 }

--- a/src/fundus_lesions_toolkit/models/segmentation.py
+++ b/src/fundus_lesions_toolkit/models/segmentation.py
@@ -4,7 +4,7 @@ from typing import Literal, Union
 from functools import lru_cache
 
 import numpy as np
-import segmentation_models_pytorch as smp
+import torchseg
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -28,11 +28,10 @@ EncoderModel = Literal["resnet34"]
 TrainedOn = Literal["ALL"]
 
 
-
 def segment(
     image: np.ndarray,
     arch: Architecture = "unet",
-    encoder: EncoderModel = "timm-resnest50d",
+    encoder: EncoderModel = "resnest50d",
     weights: TrainedOn = "All",
     image_resolution=1536,
     autofit_resolution=True,
@@ -87,7 +86,9 @@ def segment(
         pred = model.segmentation_head(pre_segmentation_features)
         pred = F.softmax(pred, 1)
         if return_features or return_decoder_features:
-            assert not reverse_autofit, "reverse_autofit is not compatible with return_features or return_decoder_features"
+            assert (
+                not reverse_autofit
+            ), "reverse_autofit is not compatible with return_features or return_decoder_features"
             out = [pred]
             if return_features:
                 out.append(features[features_layer])
@@ -168,6 +169,7 @@ def batch_segment(
 
     return pred
 
+
 @lru_cache(maxsize=2)
 def get_model(
     arch: Architecture = "unet",
@@ -188,7 +190,6 @@ def get_model(
         nn.Module: Torch segmentation model
     """
 
-    
     model = segmentation_model(arch=arch, encoder=encoder, weights=weights).to(
         device=device
     )
@@ -208,7 +209,7 @@ def segmentation_model(arch: Architecture, encoder: EncoderModel, weights: Train
         model_key in DOWNLOADABLE_MODELS.keys()
     ), f"Wrong combinations of architecture, encoder and weights asked {(arch, encoder, weights)}. Call list_models() to see all configurations acceptable"
 
-    model = smp.create_model(
+    model = torchseg.create_model(
         arch=arch, encoder_name=encoder, encoder_weights=None, in_channels=3, classes=5
     )
 
@@ -220,6 +221,11 @@ def segmentation_model(arch: Architecture, encoder: EncoderModel, weights: Train
     state_dict = torch.hub.load_state_dict_from_url(
         url, map_location="cpu", file_name=model_name, model_dir=model_dir
     )
+
+    # The models were trained with the segmentatation-models-pytorch library, which uses a different naming convention
+    state_dict = {
+        k.replace("encoder", "encoder.model"): v for k, v in state_dict.items()
+    }
 
     model.load_state_dict(state_dict=state_dict, strict=True)
     if model_key in MODELS_TRAINED_WITH_DROPOUT:

--- a/src/fundus_lesions_toolkit/models/segmentation.py
+++ b/src/fundus_lesions_toolkit/models/segmentation.py
@@ -49,7 +49,7 @@ def segment(
     Args:
         image (np.ndarray):   Fundus image of size HxWx3
         arch (Architecture, optional): Defaults to 'unet'.
-        encoder (EncoderModel, optional): Defaults to 'timm-resnest50d'.
+        encoder (EncoderModel, optional): Defaults to 'resnest50d'.
         weights (TrainedOn, optional):  Defaults to 'All'.
         image_resolution (int, optional): Defaults to 1536.
         mean (list, optional): Defaults to constants.DEFAULT_NORMALIZATION_MEAN.
@@ -108,7 +108,7 @@ def segment(
 def batch_segment(
     batch: Union[torch.Tensor, np.ndarray],
     arch: Architecture = "unet",
-    encoder: EncoderModel = "timm-resnest50d",
+    encoder: EncoderModel = "resnest50d",
     weights: TrainedOn = "All",
     already_normalized=False,
     mean=None,
@@ -123,7 +123,7 @@ def batch_segment(
     Args:
         batch (Union[torch.Tensor, np.ndarray]): Batch of fundus images of size BxHxWx3 or Bx3xHxW
         arch (Architecture, optional): Defaults to 'unet'.
-        encoder (EncoderModel, optional): Defaults to 'timm-resnest50d'.
+        encoder (EncoderModel, optional): Defaults to 'resnest50d'.
         weights (TrainedOn, optional):  Defaults to 'All'.
         already_normalized (bool, optional): Defaults to False.
         mean (list, optional): Defaults to constants.DEFAULT_NORMALIZATION_MEAN.
@@ -173,7 +173,7 @@ def batch_segment(
 @lru_cache(maxsize=2)
 def get_model(
     arch: Architecture = "unet",
-    encoder: EncoderModel = "timm-resnest50d",
+    encoder: EncoderModel = "resnest50d",
     weights: TrainedOn = "All",
     device: torch.device = "cuda",
     compile: bool = False,
@@ -182,7 +182,7 @@ def get_model(
 
     Args:
         arch (Architecture, optional): Defaults to 'unet'.
-        encoder (EncoderModel, optional):  Defaults to 'timm-resnest50d'.
+        encoder (EncoderModel, optional):  Defaults to 'resnest50d'.
         weights (TrainedOn, optional):  Defaults to 'All'.
         device (torch.device, optional): Defaults to "cuda".
 


### PR DESCRIPTION
SMP appears to [not be very actively maintained anymore](https://github.com/qubvel/segmentation_models.pytorch/issues/849). 

[`torchseg`](https://github.com/isaaccorley/torchseg) is a fork that
- Supports recent `timm` versions, whereas SMP pins `timm==0.9.7`
- Supports ViT encoders (not necessary at the moment, but could be useful in the future)
- Has fewer dependencies (SMP notably depends on `efficientnet-pytorch` and `pretrainedmodels`, both of which are also unmaintained, and are superseded by `timm` anyway)

Minimum Python version is bumped to 3.9 to match `torchseg` (3.5 has long reached end-of-life status).